### PR TITLE
Fix Codex MCP startup in hub mode without standalone SDK peers

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "scripts": {
     "mcp": "node src/server.mjs",
+    "test": "node --test test/*.test.mjs",
     "build:client": "tsdown src/client/index.tsx --format cjs --platform browser --target es2022 --tsconfig tsconfig.client.json --deps.never-bundle react --deps.never-bundle react/jsx-runtime --deps.never-bundle react-dom --deps.never-bundle react-dom/client --out-dir .client-build --clean --logLevel warn && node scripts/build-client.mjs"
   },
   "dependencies": {

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -3,8 +3,17 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
-import { startJob, waitJob, cancelJob, listJobs, getJob, jobView } from './jobs.mjs';
 import { hubAvailable, hub } from './hub-client.mjs';
+
+// The standalone job manager depends on @deepseek-ai/* peer dependencies that
+// are available inside the DSH host module realm, but not necessarily to this
+// external MCP process. Hub mode does not need those dependencies, so load the
+// standalone path only if a request actually resolves to it.
+let standaloneJobsPromise;
+function standaloneJobs() {
+  standaloneJobsPromise ??= import('./jobs.mjs');
+  return standaloneJobsPromise;
+}
 
 const server = new McpServer({ name: 'dsh-crew', version: '0.1.0' });
 
@@ -95,6 +104,7 @@ server.registerTool('dsh_run_worker', {
       const spawned = await hub.spawn({ task, tier: t, effort: e, cwd: workDir, source: ORCHESTRATOR, preset: presetForTier(t) });
       return await hub.get(spawned.id, timeout);
     }
+    const { startJob, waitJob, jobView } = await standaloneJobs();
     const job = startJob({ task, tier: t, effort: e, cwd: workDir, timeoutMs: timeout * 1000, source: ORCHESTRATOR });
     await waitJob(job.id, timeout * 1000);
     return jobView(job, { withResult: true });
@@ -152,6 +162,7 @@ server.registerTool('dsh_spawn_worker', {
   const t = applyTierPolicy(tier);
   const e = effort ?? sessionConfig.default_effort;
   if ((await resolveMode()) === 'hub') return text(await hub.spawn({ task, tier: t, effort: e, cwd: workDir, source: ORCHESTRATOR, preset: presetForTier(t) }));
+  const { startJob, jobView } = await standaloneJobs();
   const job = startJob({ task, tier: t, effort: e, cwd: workDir, source: ORCHESTRATOR });
   return text(jobView(job));
 });
@@ -161,7 +172,8 @@ server.registerTool('dsh_worker_status', {
   description: 'List all DSH worker jobs in this session with live progress (turn/step, current tool, token usage).',
   inputSchema: {},
 }, async () => {
-  const local = listJobs().map((j) => jobView(j));
+  const jobs = standaloneJobsPromise ? await standaloneJobsPromise : null;
+  const local = jobs ? jobs.listJobs().map((j) => jobs.jobView(j)) : [];
   const remote = (await hubAvailable()) ? await hub.list().catch(() => []) : [];
   return text([...remote, ...local]);
 });
@@ -178,6 +190,7 @@ server.registerTool('dsh_worker_result', {
     if (!(await hubAvailable())) return text({ error: 'hub not reachable' });
     return text(await hub.get(job_id, wait_seconds).catch((e) => ({ error: e.message })));
   }
+  const { getJob, waitJob, jobView } = await standaloneJobs();
   if (!getJob(job_id)) return text({ error: `no such job: ${job_id}` });
   const job = await waitJob(job_id, wait_seconds > 0 ? wait_seconds * 1000 : 1);
   return text(jobView(job, { withResult: true }));
@@ -192,6 +205,7 @@ server.registerTool('dsh_worker_cancel', {
     if (!(await hubAvailable())) return text({ error: 'hub not reachable' });
     return text(await hub.cancel(job_id).catch((e) => ({ error: e.message })));
   }
+  const { getJob, cancelJob, jobView } = await standaloneJobs();
   if (!getJob(job_id)) return text({ error: `no such job: ${job_id}` });
   return text(jobView(await cancelJob(job_id), { withResult: true }));
 });

--- a/test/fixtures/reject-standalone-jobs-loader.mjs
+++ b/test/fixtures/reject-standalone-jobs-loader.mjs
@@ -1,0 +1,6 @@
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === './jobs.mjs' && context.parentURL?.endsWith('/src/server.mjs')) {
+    throw new Error('standalone jobs module must not load during MCP startup');
+  }
+  return nextResolve(specifier, context);
+}

--- a/test/server-hub-lazy-loading.test.mjs
+++ b/test/server-hub-lazy-loading.test.mjs
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const LOADER = resolve(ROOT, 'test/fixtures/reject-standalone-jobs-loader.mjs');
+
+function waitForResponse(child, id) {
+  return new Promise((resolveResponse, reject) => {
+    let buffer = '';
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`timed out waiting for MCP response ${id}`));
+    }, 5_000);
+
+    const onData = (chunk) => {
+      buffer += chunk;
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        const message = JSON.parse(line);
+        if (message.id === id) {
+          cleanup();
+          resolveResponse(message);
+          return;
+        }
+      }
+    };
+    const onExit = (code, signal) => {
+      cleanup();
+      reject(new Error(`MCP server exited before response ${id}: code=${code} signal=${signal}`));
+    };
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.stdout.off('data', onData);
+      child.off('exit', onExit);
+    };
+
+    child.stdout.on('data', onData);
+    child.on('exit', onExit);
+  });
+}
+
+function send(child, message) {
+  child.stdin.write(`${JSON.stringify(message)}\n`);
+}
+
+test('MCP starts and exposes hub tools without loading standalone jobs', async (t) => {
+  const requests = [];
+  const hub = createServer((request, response) => {
+    requests.push({ method: request.method, url: request.url });
+    response.setHeader('content-type', 'application/json');
+    if (request.method === 'GET' && request.url === '/_dsh/dsh-crew/ping') {
+      response.end(JSON.stringify({ ok: true, service: 'dsh-crew-hub' }));
+      return;
+    }
+    if (request.method === 'POST' && request.url === '/_dsh/dsh-crew/jobs') {
+      response.end(JSON.stringify({ ok: true, job: { id: 'hub-test' } }));
+      return;
+    }
+    if (request.method === 'GET' && request.url?.startsWith('/_dsh/dsh-crew/jobs/hub-test?wait=')) {
+      response.end(JSON.stringify({
+        ok: true,
+        job: {
+          id: 'hub-test',
+          model: 'deepseek-v4-flash',
+          status: 'done',
+          result: 'ok',
+        },
+      }));
+      return;
+    }
+    response.statusCode = 404;
+    response.end(JSON.stringify({ ok: false, error: 'not found' }));
+  });
+  hub.listen(0, '127.0.0.1');
+  await once(hub, 'listening');
+  const address = hub.address();
+  assert.ok(address && typeof address !== 'string');
+
+  const home = await mkdtemp(resolve(tmpdir(), 'dsh-crew-test-'));
+  const configDir = resolve(home, '.config/dsh-crew');
+  await mkdir(configDir, { recursive: true });
+  await writeFile(resolve(configDir, 'config.json'), JSON.stringify({
+    mode: 'hub',
+    hub_url: `http://127.0.0.1:${address.port}`,
+  }));
+
+  const child = spawn(process.execPath, [
+    '--experimental-loader',
+    LOADER,
+    resolve(ROOT, 'src/server.mjs'),
+  ], {
+    cwd: ROOT,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, HOME: home },
+  });
+
+  let stderr = '';
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
+
+  t.after(async () => {
+    if (child.exitCode === null) child.kill('SIGTERM');
+    if (child.exitCode === null) await once(child, 'exit');
+    await new Promise((resolveClose, rejectClose) => {
+      hub.close((error) => error ? rejectClose(error) : resolveClose());
+    });
+    await rm(home, { recursive: true, force: true });
+  });
+
+  const initializeResponse = waitForResponse(child, 1);
+  send(child, {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2025-06-18',
+      capabilities: {},
+      clientInfo: { name: 'dsh-crew-test', version: '1.0.0' },
+    },
+  });
+  const initialized = await initializeResponse;
+  assert.equal(initialized.error, undefined, stderr);
+
+  send(child, { jsonrpc: '2.0', method: 'notifications/initialized' });
+  const toolsResponse = waitForResponse(child, 2);
+  send(child, { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+  const tools = await toolsResponse;
+  assert.equal(tools.error, undefined, stderr);
+  assert.ok(tools.result.tools.some((tool) => tool.name === 'dsh_run_worker'));
+
+  const callResponse = waitForResponse(child, 3);
+  send(child, {
+    jsonrpc: '2.0',
+    id: 3,
+    method: 'tools/call',
+    params: {
+      name: 'dsh_run_worker',
+      arguments: {
+        task: 'Reply with exactly the word: ok',
+        tier: 'flash',
+        effort: 'off',
+        cwd: ROOT,
+      },
+    },
+  });
+  const call = await callResponse;
+  assert.equal(call.error, undefined, stderr);
+  const result = JSON.parse(call.result.content[0].text);
+  assert.equal(result.model, 'deepseek-v4-flash');
+  assert.equal(result.status, 'done');
+  assert.equal(result.result, 'ok');
+  assert.deepEqual(requests.map(({ method, url }) => `${method} ${url}`), [
+    'GET /_dsh/dsh-crew/ping',
+    'POST /_dsh/dsh-crew/jobs',
+    'GET /_dsh/dsh-crew/jobs/hub-test?wait=1800',
+  ]);
+});


### PR DESCRIPTION
## Summary

- lazily load the standalone job manager only when execution resolves to standalone mode
- keep hub-mode MCP startup independent of DeepSeek SDK peer dependencies from the DSH host module realm
- preserve local job status, result, and cancellation behavior after the standalone module has been loaded
- add an MCP protocol regression test that rejects any attempt to import `jobs.mjs`, then verifies initialization, tool discovery, and a complete `dsh_run_worker` call through a fake hub

## Root cause

The generated Codex integration launches `src/server.mjs` as an external Node.js process. That entry point eagerly imported `jobs.mjs`, which imports `@deepseek-ai/dsh-sdk-client`. The SDK is provided inside the DSH host module realm, but it is not necessarily resolvable by the external MCP process.

Because the import happened before `hubAvailable()`, hub mode failed even though it does not use the standalone SDK.

## Validation

- `npm test`
  - MCP initializes while a test loader rejects every `jobs.mjs` import
  - `dsh_run_worker` is listed
  - a complete hub-mode tool call returns `deepseek-v4-flash`, `done`, and `ok`
- `git diff --check`
- `npm pack --dry-run`
- live local integration with the generated Codex MCP command and a running DSH hub:
  - source: `codex`
  - model: `deepseek-v4-flash`
  - mode: `hub`
  - status: `done`
  - result: `DSH_FLASH_CHAIN_OK`

Closes #1