### PR TITLE
fix(install): ship the marketplace the installer registers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "dsh-crew",
+  "owner": {
+    "name": "ZSeven-W"
+  },
+  "description": "Dispatch subtasks to DeepSeek Harness (DSH) agents as native subagents with live progress",
+  "plugins": [
+    {
+      "name": "dsh-crew",
+      "source": "./",
+      "description": "Dispatch subtasks to DeepSeek Harness (DSH) agents as native subagents with live progress",
+      "category": "productivity"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ One-click installation (choose one):
 - **DSH settings page** (when hub mode is installed): Settings → DSH Crew → "Install to Claude Code"
 - **Command line**: `node src/install/cli.mjs all`
 
-Both do the same thing: register local marketplace (parent directory `dsh-plugins/` as marketplace root) + `claude plugin install` + MCP tool permission allowlist + claude-hud worker status segment config (auto-backup settings.json before changes, idempotent). **Restart the session after installation for changes to take effect.**
+Both do the same thing: register local marketplace (the repo itself, via `.claude-plugin/marketplace.json`) + `claude plugin install` + MCP tool permission allowlist + claude-hud worker status segment config (auto-backup settings.json before changes, idempotent). **Restart the session after installation for changes to take effect.**
 
 ### Usage
 

--- a/src/install/install.mjs
+++ b/src/install/install.mjs
@@ -142,12 +142,11 @@ export function uninstallCodex({ home = homedir() } = {}) {
 export async function installClaudeCode({ home = homedir(), statusline = false } = {}) {
   const actions = [];
 
-  // The marketplace root is the PARENT directory (dsh-plugins/): marketplace
-  // plugin sources must be './<subdir>' paths inside the marketplace root, so
-  // the plugin repo itself cannot be its own marketplace and a wrapper
-  // directory elsewhere cannot reference it either.
-  const mpDir = dirname(ROOT);
-  actions.push(`marketplace: ${mpDir} (parent-dir marketplace, source ./dsh-crew)`);
+  // The repo is its own marketplace: .claude-plugin/marketplace.json lists the
+  // plugin with source './'. Pointing at the parent directory instead would
+  // need a manifest written into whatever directory the user cloned into.
+  const mpDir = ROOT;
+  actions.push(`marketplace: ${mpDir} (self-marketplace, source ./)`);
 
   // 2. settings.json: marketplace + enabledPlugins + permissions allowlist.
   const settingsFile = join(home, '.claude', 'settings.json');
@@ -217,7 +216,15 @@ export async function installClaudeCode({ home = homedir(), statusline = false }
     const { execSync } = await import('node:child_process');
     const run = (cmd) => execSync(cmd, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 120_000 });
     try { run(`claude plugin marketplace add ${JSON.stringify(mpDir)}`); actions.push('cli: marketplace registered'); }
-    catch { actions.push('cli: marketplace add skipped (already registered)'); }
+    catch (err) {
+      // Re-adding an existing marketplace is the expected no-op; anything else
+      // is a real failure (a missing or invalid manifest, say) and must be said
+      // out loud — reporting it as "already registered" hides the cause of the
+      // `plugin install` error that follows.
+      const msg = String(err?.stdout ?? '') + String(err?.stderr ?? '') + String(err?.message ?? err);
+      if (/already/i.test(msg)) actions.push('cli: marketplace add skipped (already registered)');
+      else actions.push(`cli: marketplace add failed — ${msg.replace(/\s+/g, ' ').trim().slice(0, 160)}`);
+    }
     // `plugin install` on an already-installed plugin is a no-op and leaves a
     // stale snapshot in ~/.claude/plugins/cache — uninstall first so an update
     // always re-copies the current code.


### PR DESCRIPTION
## The problem

On a fresh clone, `node src/install/cli.mjs claude` fails:

```
• marketplace: ~/src (parent-dir marketplace, source ./dsh-crew)
• settings: registered dsh-crew@dsh-crew + 5 permission rules
• cli: marketplace add skipped (already registered)
• cli: plugin install failed — run manually: claude plugin install dsh-crew@dsh-crew -y
```

Running the suggested command by hand gives the actual error:

```
✘ Failed to install plugin "dsh-crew@dsh-crew": Plugin "dsh-crew" not found in marketplace "dsh-crew".
```

`installClaudeCode` registers `dirname(ROOT)` — the clone's parent directory — as a Claude Code directory marketplace. But no `marketplace.json` is ever written there: not by this repo, not by the installer, and the README does not ask the user to create one. It works on a machine where that parent directory happens to already be a marketplace; on any other clone `claude plugin marketplace add` fails on the missing manifest, and `plugin install` then has nothing to resolve `dsh-crew` from.

The cause is invisible in the output, which is what makes this one hard to chase. The `catch` around `marketplace add` reports *every* failure as `already registered`, so the log blames the install step for a problem in the step before it.

## The change

The repo becomes its own marketplace.

- **New `.claude-plugin/marketplace.json`** — lists the plugin with `"source": "./"`, the usual shape for a single-plugin marketplace. `.claude-plugin` is already in the `files` list in `package.json`, so it ships with the package.
- **`mpDir = ROOT`** instead of `dirname(ROOT)`, which drops the requirement that the clone live in a particular directory. The comment claiming a plugin repo cannot be its own marketplace is not accurate — `"source": "./"` resolves against the marketplace root, and that is the marketplace root.
- **The `marketplace add` catch** now says `already registered` only when the CLI actually said so, and prints the real error text otherwise.
- **README** wording updated to match. The translated `README.*.md` files still describe the old layout — they look machine-generated by this project's own worker fan-out, so I left them for you to regenerate rather than hand-editing 14 files.

The manifest deliberately carries **no `version` field**, so it does not add a fifth place for the release version to drift out of, and `smoke:pack`'s version guard needs no change.

## Verification

Ran on a clone whose parent is an ordinary directory of unrelated repositories:

```
• marketplace: ~/src/dsh-crew (self-marketplace, source ./)
• settings: registered dsh-crew@dsh-crew + 5 permission rules
• cli: marketplace registered
• cli: plugin snapshot refreshed (dsh-crew@dsh-crew)
done.
```

`claude plugin list` then reports `dsh-crew@dsh-crew`, version `0.1.0-rc.6`, user scope, enabled, and `~/.claude/plugins/known_marketplaces.json` points the `dsh-crew` marketplace at the repo directory. The plugin's MCP server, which had been failing to connect, connects on the next session.

## One thing I did not touch

`uninstallClaudeCode` has a legacy array-form branch that filters `extraKnownMarketplaces` on `~/.config/dsh-crew/marketplace` — a path no version of the installer writes. It is dead against both the old and the new layout, so it is unrelated to this fix, but you may want it.
