### PR TITLE
fix(install,hub): mirror CLI cleanup on uninstall; accept Windows and relative cwd

### DIFF
--- a/lib/server.mjs
+++ b/lib/server.mjs
@@ -774,7 +774,7 @@ var require_uri_all = __commonJS({
         target.fragment = relative2.fragment;
         return target;
       }
-      function resolve5(baseURI, relativeURI, options) {
+      function resolve6(baseURI, relativeURI, options) {
         var schemelessOptions = assign({ scheme: "null" }, options);
         return serialize(resolveComponents(parse(baseURI, schemelessOptions), parse(relativeURI, schemelessOptions), schemelessOptions, true), schemelessOptions);
       }
@@ -1039,7 +1039,7 @@ var require_uri_all = __commonJS({
       exports2.removeDotSegments = removeDotSegments;
       exports2.serialize = serialize;
       exports2.resolveComponents = resolveComponents;
-      exports2.resolve = resolve5;
+      exports2.resolve = resolve6;
       exports2.normalize = normalize;
       exports2.equal = equal;
       exports2.escapeComponent = escapeComponent;
@@ -1392,18 +1392,18 @@ var require_resolve = __commonJS({
     var util2 = require_util();
     var SchemaObject = require_schema_obj();
     var traverse = require_json_schema_traverse();
-    module.exports = resolve5;
-    resolve5.normalizeId = normalizeId;
-    resolve5.fullPath = getFullPath;
-    resolve5.url = resolveUrl;
-    resolve5.ids = resolveIds;
-    resolve5.inlineRef = inlineRef;
-    resolve5.schema = resolveSchema;
-    function resolve5(compile, root, ref) {
+    module.exports = resolve6;
+    resolve6.normalizeId = normalizeId;
+    resolve6.fullPath = getFullPath;
+    resolve6.url = resolveUrl;
+    resolve6.ids = resolveIds;
+    resolve6.inlineRef = inlineRef;
+    resolve6.schema = resolveSchema;
+    function resolve6(compile, root, ref) {
       var refVal = this._refs[ref];
       if (typeof refVal == "string") {
         if (this._refs[refVal]) refVal = this._refs[refVal];
-        else return resolve5.call(this, compile, root, refVal);
+        else return resolve6.call(this, compile, root, refVal);
       }
       refVal = refVal || this._schemas[ref];
       if (refVal instanceof SchemaObject) {
@@ -1608,7 +1608,7 @@ var require_resolve = __commonJS({
 var require_error_classes = __commonJS({
   "node_modules/.pnpm/ajv@6.15.0/node_modules/ajv/lib/compile/error_classes.js"(exports, module) {
     "use strict";
-    var resolve5 = require_resolve();
+    var resolve6 = require_resolve();
     module.exports = {
       Validation: errorSubclass(ValidationError),
       MissingRef: errorSubclass(MissingRefError)
@@ -1623,8 +1623,8 @@ var require_error_classes = __commonJS({
     };
     function MissingRefError(baseId, ref, message) {
       this.message = message || MissingRefError.message(baseId, ref);
-      this.missingRef = resolve5.url(baseId, ref);
-      this.missingSchema = resolve5.normalizeId(resolve5.fullPath(this.missingRef));
+      this.missingRef = resolve6.url(baseId, ref);
+      this.missingSchema = resolve6.normalizeId(resolve6.fullPath(this.missingRef));
     }
     function errorSubclass(Subclass) {
       Subclass.prototype = Object.create(Error.prototype);
@@ -2152,7 +2152,7 @@ var require_validate = __commonJS({
 var require_compile = __commonJS({
   "node_modules/.pnpm/ajv@6.15.0/node_modules/ajv/lib/compile/index.js"(exports, module) {
     "use strict";
-    var resolve5 = require_resolve();
+    var resolve6 = require_resolve();
     var util2 = require_util();
     var errorClasses = require_error_classes();
     var stableStringify = require_fast_json_stable_stringify();
@@ -2214,7 +2214,7 @@ var require_compile = __commonJS({
           RULES,
           validate: validateGenerator,
           util: util2,
-          resolve: resolve5,
+          resolve: resolve6,
           resolveRef,
           usePattern,
           useDefault,
@@ -2276,7 +2276,7 @@ var require_compile = __commonJS({
         return validate;
       }
       function resolveRef(baseId2, ref, isRoot) {
-        ref = resolve5.url(baseId2, ref);
+        ref = resolve6.url(baseId2, ref);
         var refIndex = refs[ref];
         var _refVal, refCode;
         if (refIndex !== void 0) {
@@ -2293,11 +2293,11 @@ var require_compile = __commonJS({
           }
         }
         refCode = addLocalRef(ref);
-        var v2 = resolve5.call(self, localCompile, root, ref);
+        var v2 = resolve6.call(self, localCompile, root, ref);
         if (v2 === void 0) {
           var localSchema = localRefs && localRefs[ref];
           if (localSchema) {
-            v2 = resolve5.inlineRef(localSchema, opts.inlineRefs) ? localSchema : compile.call(self, localSchema, root, localRefs, baseId2);
+            v2 = resolve6.inlineRef(localSchema, opts.inlineRefs) ? localSchema : compile.call(self, localSchema, root, localRefs, baseId2);
           }
         }
         if (v2 === void 0) {
@@ -5914,7 +5914,7 @@ var require_ajv = __commonJS({
   "node_modules/.pnpm/ajv@6.15.0/node_modules/ajv/lib/ajv.js"(exports, module) {
     "use strict";
     var compileSchema = require_compile();
-    var resolve5 = require_resolve();
+    var resolve6 = require_resolve();
     var Cache = require_cache();
     var SchemaObject = require_schema_obj();
     var stableStringify = require_fast_json_stable_stringify();
@@ -5996,7 +5996,7 @@ var require_ajv = __commonJS({
       var id = this._getId(schema);
       if (id !== void 0 && typeof id != "string")
         throw new Error("schema id must be string");
-      key = resolve5.normalizeId(key || id);
+      key = resolve6.normalizeId(key || id);
       checkUnique(this, key);
       this._schemas[key] = this._addSchema(schema, _skipValidation, _meta, true);
       return this;
@@ -6040,7 +6040,7 @@ var require_ajv = __commonJS({
       }
     }
     function _getSchemaFragment(self, ref) {
-      var res = resolve5.schema.call(self, { schema: {} }, ref);
+      var res = resolve6.schema.call(self, { schema: {} }, ref);
       if (res) {
         var schema = res.schema, root = res.root, baseId = res.baseId;
         var v = compileSchema.call(self, schema, root, void 0, baseId);
@@ -6056,7 +6056,7 @@ var require_ajv = __commonJS({
       }
     }
     function _getSchemaObj(self, keyRef) {
-      keyRef = resolve5.normalizeId(keyRef);
+      keyRef = resolve6.normalizeId(keyRef);
       return self._schemas[keyRef] || self._refs[keyRef] || self._fragments[keyRef];
     }
     function removeSchema(schemaKeyRef) {
@@ -6083,7 +6083,7 @@ var require_ajv = __commonJS({
           this._cache.del(cacheKey);
           var id = this._getId(schemaKeyRef);
           if (id) {
-            id = resolve5.normalizeId(id);
+            id = resolve6.normalizeId(id);
             delete this._schemas[id];
             delete this._refs[id];
           }
@@ -6107,13 +6107,13 @@ var require_ajv = __commonJS({
       var cached = this._cache.get(cacheKey);
       if (cached) return cached;
       shouldAddSchema = shouldAddSchema || this._opts.addUsedSchema !== false;
-      var id = resolve5.normalizeId(this._getId(schema));
+      var id = resolve6.normalizeId(this._getId(schema));
       if (id && shouldAddSchema) checkUnique(this, id);
       var willValidate = this._opts.validateSchema !== false && !skipValidation;
       var recursiveMeta;
-      if (willValidate && !(recursiveMeta = id && id == resolve5.normalizeId(schema.$schema)))
+      if (willValidate && !(recursiveMeta = id && id == resolve6.normalizeId(schema.$schema)))
         this.validateSchema(schema, true);
-      var localRefs = resolve5.ids.call(this, schema);
+      var localRefs = resolve6.ids.call(this, schema);
       var schemaObj = new SchemaObject({
         id,
         schema,
@@ -11473,7 +11473,7 @@ var Protocol = class {
    */
   request(request, resultSchema, options) {
     const { relatedRequestId, resumptionToken, onresumptiontoken } = options !== null && options !== void 0 ? options : {};
-    return new Promise((resolve5, reject) => {
+    return new Promise((resolve6, reject) => {
       var _a, _b, _c, _d, _e, _f;
       if (!this._transport) {
         reject(new Error("Not connected"));
@@ -11524,7 +11524,7 @@ var Protocol = class {
         }
         try {
           const result = resultSchema.parse(response.result);
-          resolve5(result);
+          resolve6(result);
         } catch (error) {
           reject(error);
         }
@@ -13870,12 +13870,12 @@ var StdioServerTransport = class {
     (_a = this.onclose) === null || _a === void 0 ? void 0 : _a.call(this);
   }
   send(message) {
-    return new Promise((resolve5) => {
+    return new Promise((resolve6) => {
       const json = serializeMessage(message);
       if (this._stdout.write(json)) {
-        resolve5();
+        resolve6();
       } else {
-        this._stdout.once("drain", resolve5);
+        this._stdout.once("drain", resolve6);
       }
     });
   }
@@ -14902,6 +14902,23 @@ async function startCliJob({ worker, task, cwd, timeoutMs = DEFAULT_TIMEOUT_MS, 
   return job;
 }
 
+// src/paths.mjs
+import { isAbsolute, resolve as resolve5, posix, win32 } from "node:path";
+function isAbsoluteCwd(cwd) {
+  if (typeof cwd !== "string" || cwd === "") return false;
+  return posix.isAbsolute(cwd) || win32.isAbsolute(cwd);
+}
+function resolveWorkerCwd(cwd, base = process.cwd()) {
+  if (cwd === void 0 || cwd === null || cwd === "" || cwd === "." || cwd === "current") return resolve5(base);
+  if (isAbsoluteCwd(cwd)) return canonicalCwd(cwd);
+  return resolve5(base, cwd);
+}
+function canonicalCwd(cwd) {
+  if (isAbsolute(cwd)) return resolve5(cwd);
+  if (win32.isAbsolute(cwd)) return win32.normalize(cwd);
+  return posix.normalize(cwd);
+}
+
 // src/server.mjs
 import { createRequire } from "node:module";
 var server = new McpServer({ name: "dsh-crew", version: "0.1.0-rc.6" });
@@ -15002,13 +15019,13 @@ server.registerTool("dsh_run_worker", {
     tier: tierSchema,
     effort: effortSchema,
     worker: workerSchema,
-    cwd: external_exports.string().optional().describe("Workspace directory for the worker (defaults to current project)"),
+    cwd: external_exports.string().optional().describe(`Workspace directory for the worker. Relative paths resolve against the caller's current workspace; "." or "current" mean the current workspace. Omit for the current workspace.`),
     timeout_seconds: external_exports.number().int().positive().max(7200).optional(),
     allow_concurrent_cwd: allowConcurrentCwdSchema
   }
 }, async ({ task, tier, effort, worker, cwd, timeout_seconds, allow_concurrent_cwd }) => {
   if (!sessionConfig.enabled) return dispatchDisabled();
-  const workDir = cwd ?? process.cwd();
+  const workDir = resolveWorkerCwd(cwd);
   const e = effort ?? sessionConfig.default_effort;
   const timeout = timeout_seconds ?? sessionConfig.default_timeout_seconds;
   const depthLimit = depthLimitNow();
@@ -15117,12 +15134,12 @@ server.registerTool("dsh_spawn_worker", {
     tier: tierSchema,
     effort: effortSchema,
     worker: workerSchema,
-    cwd: external_exports.string().optional(),
+    cwd: external_exports.string().optional().describe(`Workspace directory for the worker. Relative paths resolve against the caller's current workspace; "." or "current" mean the current workspace. Omit for the current workspace.`),
     allow_concurrent_cwd: allowConcurrentCwdSchema
   }
 }, async ({ task, tier, effort, worker, cwd, allow_concurrent_cwd }) => {
   if (!sessionConfig.enabled) return dispatchDisabled();
-  const workDir = cwd ?? process.cwd();
+  const workDir = resolveWorkerCwd(cwd);
   const depthLimit = depthLimitNow();
   if (worker) {
     const profile = resolveProfile(worker);

--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
     "build": "npm run build:client && npm run build:mcp",
     "build:client": "tsdown src/client/index.tsx --format cjs --platform browser --target es2022 --tsconfig tsconfig.client.json --deps.never-bundle react --deps.never-bundle react/jsx-runtime --deps.never-bundle react-dom --deps.never-bundle react-dom/client --out-dir .client-build --clean --logLevel warn && node scripts/build-client.mjs",
     "build:mcp": "node scripts/build-mcp.mjs",
+    "smoke:cwd": "node scripts/smoke-cwd.mjs",
     "smoke:mcp": "node scripts/smoke-bundle.mjs",
     "smoke:pack": "node scripts/smoke-pack.mjs",
-    "prepack": "npm run smoke:mcp",
+    "prepack": "npm run smoke:cwd && npm run smoke:mcp",
     "prepublishOnly": "npm run smoke:mcp"
   },
   "dependencies": {

--- a/scripts/smoke-cwd.mjs
+++ b/scripts/smoke-cwd.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+// Smoke assertions for the cross-platform cwd helpers (issue #5): the hub
+// must accept Windows drive / UNC paths as absolute, and the MCP layer must
+// map unset / "." / "current" cwd values onto the caller's workspace while
+// relative paths resolve against it. No framework — node:assert only.
+//
+//   node scripts/smoke-cwd.mjs
+
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+import { canonicalCwd, isAbsoluteCwd, resolveWorkerCwd } from '../src/paths.mjs';
+
+// Absolute-path predicate: POSIX, Windows drive (both slash styles) and UNC.
+for (const p of ['/a/b', 'D:\\a\\b', 'C:/a/b', '\\\\srv\\share\\p']) {
+  assert.equal(isAbsoluteCwd(p), true, JSON.stringify(p) + ' should be absolute');
+}
+// Relative, empty and non-string values are never absolute.
+for (const p of ['a/b', '', undefined]) {
+  assert.equal(isAbsoluteCwd(p), false, JSON.stringify(p) + ' should not be absolute');
+}
+
+// MCP-side resolver: unset / "." / "current" mean the caller's workspace,
+// relative paths resolve against it, absolute paths normalize as-is.
+const base = resolve('project');
+assert.equal(resolveWorkerCwd(undefined, base), base);
+assert.equal(resolveWorkerCwd('.', base), base);
+assert.equal(resolveWorkerCwd('current', base), base);
+assert.equal(resolveWorkerCwd('', base), base);
+assert.equal(resolveWorkerCwd('sub/dir', base), resolve(base, 'sub/dir'));
+assert.equal(resolveWorkerCwd('/abs', base), resolve('/abs'));
+
+// Canonical form never re-roots a foreign-platform absolute path under
+// process.cwd(): a Windows path on a POSIX hub is only normalized.
+if (process.platform !== 'win32') {
+  assert.equal(canonicalCwd('D:/AI/../floorplan'), 'D:\\floorplan');
+  assert.equal(canonicalCwd('\\\\srv\\share\\p\\.'), '\\\\srv\\share\\p');
+  assert.equal(canonicalCwd('/a/../b'), '/b');
+  assert.equal(resolveWorkerCwd('D:\\AI\\floorplan', base), 'D:\\AI\\floorplan');
+}
+
+console.log('smoke-cwd: all assertions passed');

--- a/src/hub/index.mjs
+++ b/src/hub/index.mjs
@@ -6,6 +6,7 @@
 import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { isAbsoluteCwd, canonicalCwd } from '../paths.mjs';
 import { createShardWriter, readMergedStatus } from '../status-shard.mjs';
 import { procAlive, killWorkerProcess, parsePid, ProcKillRefused } from '../proc-kill.mjs';
 
@@ -96,13 +97,17 @@ class WorkerRegistry {
     const model = TIER_MODELS[tier];
     if (!model) throw new Error(`unknown tier "${tier}"`);
     if (!['off', 'high', 'max'].includes(effort)) throw new Error(`unknown effort "${effort}"`);
-    if (!cwd || !cwd.startsWith('/')) throw new Error('cwd must be an absolute path');
+    // Accept POSIX, Windows drive (D:\x, C:/x) and UNC (\\srv\share) roots.
+    if (!isAbsoluteCwd(cwd)) throw new Error('cwd must be an absolute path');
+    // One canonical form for the job, the advisory lock and the workspace
+    // lookup: D:/x and D:\x must map to the same workspace on Windows.
+    const cwdPath = canonicalCwd(cwd);
     await this.ctx.get('loader')?.await();
 
     const id = `hub-${this.nextId++}-${Date.now().toString(36)}`;
     const sessionId = `session-${randomUUID()}`;
     const job = {
-      id, sessionId, tier, model, effort, task, source, cwd,
+      id, sessionId, tier, model, effort, task, source, cwd: cwdPath,
       status: 'running', turn: 0, step: 0, currentTool: null, toolCalls: 0,
       tokens: { input: 0, output: 0, reasoning: 0 },
       startedAt: new Date().toISOString(), endedAt: null,
@@ -150,7 +155,7 @@ class WorkerRegistry {
     const run = async () => {
       const handle = await this.ctx.agents.create({
         sessionId,
-        meta: { cwd, ...(presetId === undefined ? {} : { agentPreset: presetId }) },
+        meta: { cwd: cwdPath, ...(presetId === undefined ? {} : { agentPreset: presetId }) },
         agentOptions: { provider: selection.provider, model: selection.model },
         setup: async (agentCtx) => {
           installModelSelection(agentCtx, { current: selection, assembled: undefined });
@@ -169,11 +174,11 @@ class WorkerRegistry {
         // job cwd never inherits a parent directory's workspace).
         const registry = this.ctx.get('workspaceRegistry');
         if (registry !== undefined) {
-          const ws = (await registry.resolveByPath(cwd)) ?? (await registry.create(cwd));
+          const ws = (await registry.resolveByPath(cwdPath)) ?? (await registry.create(cwdPath));
           await ws.attachSession(sessionId);
         }
       } catch (err) {
-        this.ctx.logger?.warn?.(`dsh-crew: workspace attach failed for ${cwd}: ${err?.message ?? err}`);
+        this.ctx.logger?.warn?.(`dsh-crew: workspace attach failed for ${cwdPath}: ${err?.message ?? err}`);
       }
       await handle.agent.whenIdle();
       handle.agent.followup(userMessage(task));
@@ -519,7 +524,7 @@ export async function apply(ctx) {
           if (target === 'codex') return sendJson(res, 200, installCodex({}));
           if (target === 'agy') return sendJson(res, 200, installAgy({}));
           if (target === 'grok') return sendJson(res, 200, installGrok({}));
-          if (target === 'claude-uninstall') return sendJson(res, 200, uninstallClaudeCode({}));
+          if (target === 'claude-uninstall') return sendJson(res, 200, await uninstallClaudeCode({}));
           if (target === 'codex-uninstall') return sendJson(res, 200, uninstallCodex({}));
           if (target === 'agy-uninstall') return sendJson(res, 200, uninstallAgy({}));
           if (target === 'grok-uninstall') return sendJson(res, 200, uninstallGrok({}));

--- a/src/install/install.mjs
+++ b/src/install/install.mjs
@@ -483,14 +483,31 @@ export function installHudSegment({ home = homedir() } = {}) {
   return { ok: true, actions: [...(bak ? [`backup: ${bak}`] : []), 'statusLine: claude-hud now runs worker-segment.sh via --extra-cmd'] };
 }
 
-export function uninstallClaudeCode({ home = homedir() } = {}) {
+/**
+ * Array-form extraKnownMarketplaces entries are keyed objects shaped like
+ * { "dsh-crew": { source: { source: 'directory', path } } } — never arrays
+ * of paths. Match any element that names this marketplace, or whose
+ * directory (source.path, or a top-level path for safety) resolves to the
+ * repo ROOT this installer registers.
+ */
+function isDshMarketplaceEntry(entry) {
+  if (!entry || typeof entry !== 'object') return false;
+  if (Object.prototype.hasOwnProperty.call(entry, MARKETPLACE_NAME)) return true;
+  const candidates = [entry, ...Object.values(entry).filter((v) => v && typeof v === 'object')];
+  return candidates.some((v) => {
+    const p = v.path ?? v.source?.path;
+    return typeof p === 'string' && resolve(p) === ROOT;
+  });
+}
+
+export async function uninstallClaudeCode({ home = homedir() } = {}) {
+  const actions = [];
   const settingsFile = join(home, '.claude', 'settings.json');
   const settings = readJson(settingsFile, null);
   if (!settings) return { ok: true, actions: ['settings.json not found'] };
   backup(settingsFile);
-  const mpDir = join(home, '.config', 'dsh-crew', 'marketplace');
   if (Array.isArray(settings.extraKnownMarketplaces)) {
-    settings.extraKnownMarketplaces = settings.extraKnownMarketplaces.filter((m) => m?.path !== mpDir);
+    settings.extraKnownMarketplaces = settings.extraKnownMarketplaces.filter((m) => !isDshMarketplaceEntry(m));
   } else if (settings.extraKnownMarketplaces) {
     delete settings.extraKnownMarketplaces[MARKETPLACE_NAME];
   }
@@ -503,5 +520,37 @@ export function uninstallClaudeCode({ home = homedir() } = {}) {
     settings.permissions.allow = settings.permissions.allow.filter((r) => !r.startsWith('mcp__plugin_dsh-crew_'));
   }
   writeFileSync(settingsFile, JSON.stringify(settings, null, 2) + '\n');
-  return { ok: true, actions: ['unregistered from settings.json (backup kept)'] };
+  actions.push('settings: unregistered from settings.json (backup kept)');
+
+  // Mirror install: the CLI keeps its own plugin state — known_marketplaces
+  // and the cache snapshot in ~/.claude/plugins/ — that rewriting settings
+  // alone never removes, so `claude plugin list` would still show the plugin
+  // as disabled. Best-effort, exactly like install: settings are already
+  // clean, so a missing CLI just leaves the two commands below manual.
+  if (home !== homedir()) {
+    actions.push('cli: skipped (non-default home; test mode)');
+    actions.push('unregistered from settings.json (backup kept)');
+    return { ok: true, actions };
+  }
+  const cliErrors = [];
+  try {
+    const { execSync } = await import('node:child_process');
+    const run = (cmd) => execSync(cmd, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 120_000 });
+    for (const cmd of ['claude plugin uninstall ' + PLUGIN_KEY, 'claude plugin marketplace remove ' + MARKETPLACE_NAME]) {
+      try { run(cmd); } catch (err) {
+        const msg = String(err?.stdout ?? '') + String(err?.stderr ?? '') + String(err?.message ?? err);
+        cliErrors.push(msg.replace(/\s+/g, ' ').trim().slice(0, 160));
+      }
+    }
+  } catch (err) {
+    cliErrors.push(String(err?.message ?? err).slice(0, 120));
+  }
+  if (cliErrors.length) {
+    actions.push('cli: cleanup failed — run manually: claude plugin uninstall ' + PLUGIN_KEY + '; claude plugin marketplace remove ' + MARKETPLACE_NAME + ' (' + cliErrors.join(' | ') + ')');
+    actions.push('settings.json was cleaned (backup kept) but the Claude Code CLI cleanup failed — run the commands above manually');
+    return { ok: true, actions };
+  }
+  actions.push('cli: uninstalled ' + PLUGIN_KEY + ' and removed marketplace ' + MARKETPLACE_NAME);
+  actions.push('uninstalled from Claude Code CLI and unregistered from settings.json (backup kept)');
+  return { ok: true, actions };
 }

--- a/src/paths.mjs
+++ b/src/paths.mjs
@@ -1,0 +1,43 @@
+// Cross-platform path helpers shared by the hub, the MCP server, and the
+// smoke tests. Worker cwd values may arrive from Windows agents (drive
+// letters, backslashes, UNC) or from Claude Code / Codex sessions, so every
+// absolute-path gate and cwd resolution lives here instead of a POSIX-only
+// check duplicated across backends.
+
+import { isAbsolute, resolve, posix, win32 } from 'node:path';
+
+/**
+ * True when cwd is an absolute path on any supported platform: POSIX (/a/b),
+ * Windows drive (D:\a\b, C:/a/b) or UNC (\\srv\share\p). Non-strings
+ * and the empty string are never absolute. (path.win32.isAbsolute also
+ * accepts POSIX-style roots like /x, which is fine here.)
+ */
+export function isAbsoluteCwd(cwd) {
+  if (typeof cwd !== 'string' || cwd === '') return false;
+  return posix.isAbsolute(cwd) || win32.isAbsolute(cwd);
+}
+
+/**
+ * Resolve a worker cwd the same way on every backend: undefined / null /
+ * '' / '.' / 'current' mean the caller's current workspace (base), a
+ * relative path resolves against base, and an absolute path normalizes
+ * as-is — so D:/x and D:\x map to one workspace on Windows.
+ */
+export function resolveWorkerCwd(cwd, base = process.cwd()) {
+  if (cwd === undefined || cwd === null || cwd === '' || cwd === '.' || cwd === 'current') return resolve(base);
+  if (isAbsoluteCwd(cwd)) return canonicalCwd(cwd);
+  return resolve(base, cwd);
+}
+
+/**
+ * Canonical form of an absolute cwd. A path that is absolute on this host
+ * goes through resolve(); a foreign-platform absolute path (a Windows path
+ * reaching a POSIX hub, or the reverse) is only normalized in its own
+ * flavour — never re-rooted under process.cwd(), which is what a bare
+ * resolve() would silently do.
+ */
+export function canonicalCwd(cwd) {
+  if (isAbsolute(cwd)) return resolve(cwd);
+  if (win32.isAbsolute(cwd)) return win32.normalize(cwd);
+  return posix.normalize(cwd);
+}

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -9,6 +9,7 @@ import { startCliJob } from './cli-workers.mjs';
 import { listProfiles, resolveProfile } from './worker-profiles.mjs';
 import { readInheritedOrigin, extendOrigin, DEFAULT_ORIGIN_DEPTH_LIMIT } from './origin-guard.mjs';
 import { acquireCwdLock, releaseCwdLockByJobId, updateCwdLockHolder, getCwdLocks, CwdLockError } from './cwd-lock.mjs';
+import { resolveWorkerCwd } from './paths.mjs';
 
 const server = new McpServer({ name: 'dsh-crew', version: '0.1.0-rc.6' });
 
@@ -142,13 +143,13 @@ server.registerTool('dsh_run_worker', {
     tier: tierSchema,
     effort: effortSchema,
     worker: workerSchema,
-    cwd: z.string().optional().describe('Workspace directory for the worker (defaults to current project)'),
+    cwd: z.string().optional().describe('Workspace directory for the worker. Relative paths resolve against the caller\'s current workspace; "." or "current" mean the current workspace. Omit for the current workspace.'),
     timeout_seconds: z.number().int().positive().max(7200).optional(),
     allow_concurrent_cwd: allowConcurrentCwdSchema,
   },
 }, async ({ task, tier, effort, worker, cwd, timeout_seconds, allow_concurrent_cwd }) => {
   if (!sessionConfig.enabled) return dispatchDisabled();
-  const workDir = cwd ?? process.cwd();
+  const workDir = resolveWorkerCwd(cwd);
   const e = effort ?? sessionConfig.default_effort;
   const timeout = timeout_seconds ?? sessionConfig.default_timeout_seconds;
   const depthLimit = depthLimitNow();
@@ -272,12 +273,12 @@ server.registerTool('dsh_spawn_worker', {
     tier: tierSchema,
     effort: effortSchema,
     worker: workerSchema,
-    cwd: z.string().optional(),
+    cwd: z.string().optional().describe('Workspace directory for the worker. Relative paths resolve against the caller\'s current workspace; "." or "current" mean the current workspace. Omit for the current workspace.'),
     allow_concurrent_cwd: allowConcurrentCwdSchema,
   },
 }, async ({ task, tier, effort, worker, cwd, allow_concurrent_cwd }) => {
   if (!sessionConfig.enabled) return dispatchDisabled();
-  const workDir = cwd ?? process.cwd();
+  const workDir = resolveWorkerCwd(cwd);
   const depthLimit = depthLimitNow();
   if (worker) {
     // CLI profile dispatch; no hub/standalone involvement, no tier policy.


### PR DESCRIPTION
Fixes #8, fixes #5.

- `uninstallClaudeCode` now mirrors install: best-effort `claude plugin uninstall dsh-crew@dsh-crew` + `claude plugin marketplace remove dsh-crew`, with an accurate message (and the manual commands when the CLI step fails). The legacy array branch drops entries keyed `dsh-crew` or pointing at the registered marketplace directory; the dead `~/.config/dsh-crew/marketplace` constant is gone.
- Hub accepts POSIX, Windows drive and UNC absolute paths; a foreign-platform path is normalized in its own flavour, never re-rooted under the hub's cwd. The canonical path is used for the job, the lock and the workspace lookup so `D:/x` and `D:\x` land in one workspace.
- MCP side: `cwd` omitted / `""` / `"."` / `"current"` means the caller's current workspace, relative paths resolve against it. No new field; `cwd` keeps its name.
- New `scripts/smoke-cwd.mjs`, chained into `prepack`.

Not testable on Windows from here — the Windows-path behaviour is covered by unit assertions only.

https://claude.ai/code/session_01YaSYDR2LCn9rzYhTxYHodb